### PR TITLE
Fix for directory crawler

### DIFF
--- a/src/Antlr.Core/DirectoryCrawler.cs
+++ b/src/Antlr.Core/DirectoryCrawler.cs
@@ -12,12 +12,17 @@ namespace Antlr.Core
             _statusReader = statusReader;
         }
 
-        public void DepthFirstSearch(List<FilterResult> accumulator, string directory, int level, FilterStatus parentFilterStatus, string filter, string projectUri, bool filterRemoves, bool hideChildren = false)
+        public List<FilterResult> StartSearch(string directory, FilterStatus parentFilterStatus, string filter, bool filterRemoves, bool hideChildren = false)
+        {
+            return DepthFirstSearch(new List<FilterResult>(), directory, 0, parentFilterStatus, filter, directory, filterRemoves, hideChildren);
+        }
+
+        private List<FilterResult> DepthFirstSearch(List<FilterResult> accumulator, string directory, int level, FilterStatus parentFilterStatus, string filter, string projectUri, bool filterRemoves, bool hideChildren = false)
         {
             if (hideChildren
                 && (parentFilterStatus == FilterStatus.Ignored || parentFilterStatus == FilterStatus.ParentIgnored))
             {
-                return;
+                return accumulator;
             }
             var subDirectories = Directory.EnumerateDirectories(directory);
             var thisLevel = level + 1;
@@ -28,26 +33,27 @@ namespace Antlr.Core
                     new FilterResult
                     {
                         FullPath = subDirectory,
-                        RelativePath = subDirectory.Remove(0, directory.Length),
+                        RelativePath = (thisLevel == 1 ? "." : string.Empty) + subDirectory.Remove(0, directory.Length),
                         Level = thisLevel,
                         Status = filterStatus
                     });
 
                 DepthFirstSearch(accumulator, subDirectory, thisLevel, filterStatus, filter, projectUri, filterRemoves, hideChildren);
 
-                var files = Directory.GetFiles(directory);
-                foreach (var file in files)
-                {
-                    accumulator.Add(
-                        new FilterResult
-                        {
-                            FullPath = file,
-                            RelativePath = file.Remove(0, directory.Length),
-                            Level = thisLevel,
-                            Status = _statusReader.GetFilterStatus(file, filter, parentFilterStatus, projectUri, filterRemoves)
-                        });
-                }
             }
+            var files = Directory.GetFiles(directory);
+            foreach (var file in files)
+            {
+                accumulator.Add(
+                    new FilterResult
+                    {
+                        FullPath = file,
+                        RelativePath = file.Remove(0, directory.Length),
+                        Level = thisLevel,
+                        Status = _statusReader.GetFilterStatus(file, filter, parentFilterStatus, projectUri, filterRemoves)
+                    });
+            }
+            return accumulator;
         }
     }
 }

--- a/src/Antlr/ViewModels/MainWindowViewModel.cs
+++ b/src/Antlr/ViewModels/MainWindowViewModel.cs
@@ -113,26 +113,9 @@ namespace Antlr.ViewModels
             var exists = Directory.Exists(ProjectUri);
             if (exists)
             {
-                var directories = Directory.EnumerateDirectories(ProjectUri); //could depth-first from here, but I want the root-level folders to have ./ instead of /
-
-                foreach (var directory in directories)
+                if (Recursive)
                 {
-                    var level = 1;
-                    var filterStatus = _statusReader.GetFilterStatus(directory, Filter, FilterStatus.Found, ProjectUri, FilterRemoves);
-                    filterResults.Add(
-                        new FilterResult
-                        {
-                            FullPath = directory,
-                            RelativePath = "." + directory.Remove(0, _projectUri.Length),
-                            Level = level,
-                            Status = filterStatus
-                        });
-
-                    if (Recursive)
-                    {
-                        _directoryCrawler.DepthFirstSearch(filterResults, directory, level, filterStatus, Filter, ProjectUri, FilterRemoves, HideChildren);
-                    }
-
+                    filterResults = _directoryCrawler.StartSearch(ProjectUri, FilterStatus.Found, Filter, FilterRemoves, HideChildren);
                 }
             }
             else


### PR DESCRIPTION
Improved the interface, made starting the search easier, rolled the .\ into the functioning of the crawler to reduce bloat in mainwindowviewmodel.
