### PR TITLE
Moved recurse option into the depth first search

### DIFF
--- a/src/Antlr.Core/DirectoryCrawler.cs
+++ b/src/Antlr.Core/DirectoryCrawler.cs
@@ -12,12 +12,12 @@ namespace Antlr.Core
             _statusReader = statusReader;
         }
 
-        public List<FilterResult> StartSearch(string directory, FilterStatus parentFilterStatus, string filter, bool filterRemoves, bool hideChildren = false)
+        public List<FilterResult> StartSearch(string directory, FilterStatus parentFilterStatus, string filter, bool filterRemoves, bool hideChildren = false, bool recursive = true)
         {
-            return DepthFirstSearch(new List<FilterResult>(), directory, 0, parentFilterStatus, filter, directory, filterRemoves, hideChildren);
+            return DepthFirstSearch(new List<FilterResult>(), directory, 0, parentFilterStatus, filter, directory, filterRemoves, hideChildren, recursive);
         }
 
-        private List<FilterResult> DepthFirstSearch(List<FilterResult> accumulator, string directory, int level, FilterStatus parentFilterStatus, string filter, string projectUri, bool filterRemoves, bool hideChildren = false)
+        private List<FilterResult> DepthFirstSearch(List<FilterResult> accumulator, string directory, int level, FilterStatus parentFilterStatus, string filter, string projectUri, bool filterRemoves, bool hideChildren, bool recursive)
         {
             if (hideChildren
                 && (parentFilterStatus == FilterStatus.Ignored || parentFilterStatus == FilterStatus.ParentIgnored))
@@ -38,7 +38,11 @@ namespace Antlr.Core
                         Status = filterStatus
                     });
 
-                DepthFirstSearch(accumulator, subDirectory, thisLevel, filterStatus, filter, projectUri, filterRemoves, hideChildren);
+                if (recursive)
+                {
+                    DepthFirstSearch(accumulator, subDirectory, thisLevel, filterStatus, filter, projectUri,
+                        filterRemoves, hideChildren, recursive);
+                }
 
             }
             var files = Directory.GetFiles(directory);

--- a/src/Antlr/ViewModels/MainWindowViewModel.cs
+++ b/src/Antlr/ViewModels/MainWindowViewModel.cs
@@ -113,10 +113,8 @@ namespace Antlr.ViewModels
             var exists = Directory.Exists(ProjectUri);
             if (exists)
             {
-                if (Recursive)
-                {
-                    filterResults = _directoryCrawler.StartSearch(ProjectUri, FilterStatus.Found, Filter, FilterRemoves, HideChildren);
-                }
+                filterResults = _directoryCrawler.StartSearch(ProjectUri, FilterStatus.Found, Filter, FilterRemoves,
+                    HideChildren, Recursive);
             }
             else
             {


### PR DESCRIPTION
This functionality was temporarily broken; the fix allows optional recursion down the tree from inside the DirectoryCrawler
